### PR TITLE
dq-MenuItemReview create page recreated

### DIFF
--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
@@ -1,11 +1,50 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm";
+import { Navigate } from "react-router-dom";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function PlaceholderCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function MenuItemReviewCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (review) => ({
+    url: "/api/menuitemreview/post",
+    method: "POST",
+    params: {
+      itemId: review.itemId,
+      reviewerEmail: review.reviewerEmail,
+      stars: review.stars,
+      dateReviewed: review.dateReviewed,
+      comments: review.comments,
+    },
+  });
+
+  const onSuccess = (review) => {
+    toast(
+      `New Menu Item Review Created - id: ${review.id} itemId: ${review.itemId}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/menuitemreview/all"], // mutation makes this key stale so that pages relying on it reload
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/menuitemreview" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New MenuItemReview</h1>
+        <MenuItemReviewForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewCreatePage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewCreatePage.stories.js
@@ -1,0 +1,32 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
+
+export default {
+  title: "pages/MenuItemReview/MenuItemReviewCreatePage",
+  component: MenuItemReviewCreatePage,
+};
+
+const Template = () => <MenuItemReviewCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/menuitemreview/post", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
@@ -1,17 +1,42 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
 
 describe("MenuItemReviewCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -20,15 +45,10 @@ describe("MenuItemReviewCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
+  test("renders without crashing", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -37,8 +57,88 @@ describe("MenuItemReviewCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("MenuItemReviewForm-itemId"),
+      ).toBeInTheDocument();
+    });
+  });
 
-    await screen.findByText("Create page not yet implemented");
+  test("on submit, makes request to backend, and redirects to /menuitemreview", async () => {
+    const queryClient = new QueryClient();
+    const review = {
+      id: 5,
+      itemId: 6,
+      reviewerEmail: "dqiao@ucsb.edu",
+      stars: 5,
+      dateReviewed: "2024-05-07T05:05:05",
+      comments: "splendid!",
+    };
+
+    axiosMock.onPost("/api/menuitemreview/post").reply(202, review);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Item ID")).toBeInTheDocument();
+    });
+
+    const itemInput = screen.getByLabelText("Item ID");
+    expect(itemInput).toBeInTheDocument();
+
+    const reviewerInput = screen.getByLabelText("Reviewer Email");
+    expect(reviewerInput).toBeInTheDocument();
+
+    const starsInput = screen.getByLabelText("Stars");
+    expect(starsInput).toBeInTheDocument();
+
+    const dateInput = screen.getByLabelText("Date (iso format)");
+    expect(dateInput).toBeInTheDocument();
+
+    const commentInput = screen.getByLabelText("Comments");
+    expect(commentInput).toBeInTheDocument();
+
+    const createButton = screen.getByText("Create");
+    expect(createButton).toBeInTheDocument();
+
+    fireEvent.change(itemInput, {
+      target: { value: 6 },
+    });
+    fireEvent.change(reviewerInput, {
+      target: { value: "dqiao@ucsb.edu" },
+    });
+    fireEvent.change(starsInput, {
+      target: { value: 5 },
+    });
+    fireEvent.change(dateInput, {
+      target: { value: "2024-05-07T05:05:05.000" },
+    });
+    fireEvent.change(commentInput, {
+      target: { value: "splendid!" },
+    });
+
+    fireEvent.click(createButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      itemId: "6",
+      reviewerEmail: "dqiao@ucsb.edu",
+      stars: "5",
+      dateReviewed: "2024-05-07T05:05:05.000",
+      comments: "splendid!",
+    });
+
+    // assert - check that the toast was called with the expected message
+    expect(mockToast).toBeCalledWith(
+      "New Menu Item Review Created - id: 5 itemId: 6",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/menuitemreview" });
   });
 });


### PR DESCRIPTION
Closes #40 

Storybook: https://6722c2d8d8e479c1c618f650-jkephciado.chromatic.com/?path=/docs/pages-menuitemreview-menuitemreviewcreatepage--docs

Steps: 
1. go to https://team02-st4lemon-dev.dokku-13.cs.ucsb.edu/ 
2. log in, click into MenuItemReview -> Create
3. form should look like this: 
![create1](https://github.com/user-attachments/assets/e495ea22-d02b-495b-a3df-5b619f666c84)

4. hit submit and verify error messages show up 
![create2](https://github.com/user-attachments/assets/ff4ed540-e221-41d1-a99a-97b8fb410b10)

5. put incomplete values and verify error messages show up 
![create3](https://github.com/user-attachments/assets/431df2c0-9422-481d-b6bb-59856f246c96)

6. put correct values and verify there are no error messages
![create4](https://github.com/user-attachments/assets/24784186-338e-4699-8adf-fdad46cd5dc0)

7. click submit, you should see a popup with the correct review information
8. go to swagger and use the get all endpoint to verify review was added to database