### PR TITLE
dq-MenuItemReview edit page recreated

### DIFF
--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
@@ -1,11 +1,79 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm";
+import { Navigate } from "react-router-dom";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function PlaceholderEditPage() {
-  // Stryker disable all : placeholder for future implementation
+export default function MenuItemReviewEditPage({ storybook = false }) {
+  let { id } = useParams();
+
+  const {
+    data: review,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/menuitemreview?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/menuitemreview`,
+      params: {
+        id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (review) => ({
+    url: "/api/menuitemreview",
+    method: "PUT",
+    params: {
+      id: review.id,
+    },
+    data: {
+      itemId: review.itemId,
+      reviewerEmail: review.reviewerEmail,
+      stars: review.stars,
+      dateReviewed: review.dateReviewed,
+      comments: review.comments,
+    },
+  });
+
+  const onSuccess = (review) => {
+    toast(
+      `Menu Item Review Updated - id: ${review.id} itemId: ${review.itemId}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/menuitemreview?id=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/menuitemreview" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit Menu Item Review</h1>
+        {review && (
+          <MenuItemReviewForm
+            submitAction={onSubmit}
+            buttonLabel={"Update"}
+            initialContents={review}
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewEditPage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewEditPage.stories.js
@@ -1,0 +1,42 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+
+export default {
+  title: "pages/MenuItemReview/MenuItemReviewEditPage",
+  component: MenuItemReviewEditPage,
+};
+
+const Template = () => <MenuItemReviewEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/menuitemreview", () => {
+      return HttpResponse.json(menuItemReviewFixtures.threeMenuItemReviews[0], {
+        status: 200,
+      });
+    }),
+    http.put("/api/menuitemreview", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+    http.put("/api/menuitemreview", (req) => {
+      window.alert("PUT: " + req.url + " and body: " + req.body);
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
@@ -1,43 +1,240 @@
-import { render, screen } from "@testing-library/react";
-import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    useParams: () => ({
+      id: 17,
+    }),
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
 
 describe("MenuItemReviewEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
+  describe("when the backend doesn't return data", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
-  };
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/menuitemreview", { params: { id: 17 } }).timeout();
+    });
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
+    const queryClient = new QueryClient();
+    test("renders header but table is not present", async () => {
+      const restoreConsole = mockConsole();
 
-    setupUserOnly();
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <MenuItemReviewEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText("Edit Menu Item Review");
+      expect(
+        screen.queryByTestId("MenuItemReview-itemId"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
 
-    // act
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <MenuItemReviewEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+  describe("tests where backend is working normally", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
 
-    // assert
-    await screen.findByText("Edit page not yet implemented");
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/menuitemreview", { params: { id: 17 } })
+        .reply(200, {
+          id: 17,
+          itemId: 21,
+          reviewerEmail: "dqiao@ucsb.edu",
+          stars: 5,
+          dateReviewed: "2022-03-14T15:00:00.000",
+          comments: "delicious",
+        });
+      axiosMock.onPut("/api/menuitemreview").reply(200, {
+        id: "17",
+        itemId: 22,
+        reviewerEmail: "phtcon@ucsb.edu",
+        stars: 2,
+        dateReviewed: "2022-03-15T16:02:20.200",
+        comments: "middling",
+      });
+    });
+
+    const queryClient = new QueryClient();
+
+    test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <MenuItemReviewEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("MenuItemReviewForm-id");
+
+      const idField = screen.getByTestId("MenuItemReviewForm-id");
+      const itemField = screen.getByTestId("MenuItemReviewForm-itemId");
+      const reviewerField = screen.getByTestId(
+        "MenuItemReviewForm-reviewerEmail",
+      );
+      const starsField = screen.getByTestId("MenuItemReviewForm-stars");
+      const dateField = screen.getByTestId("MenuItemReviewForm-dateReviewed");
+      const commentsField = screen.getByTestId("MenuItemReviewForm-comments");
+      const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
+
+      expect(idField).toBeInTheDocument();
+      expect(idField).toHaveValue("17");
+      expect(itemField).toBeInTheDocument();
+      expect(itemField).toHaveValue(21);
+      expect(reviewerField).toBeInTheDocument();
+      expect(reviewerField).toHaveValue("dqiao@ucsb.edu");
+      expect(starsField).toBeInTheDocument();
+      expect(starsField).toHaveValue(5);
+      expect(dateField).toBeInTheDocument();
+      expect(dateField).toHaveValue("2022-03-14T15:00");
+      expect(commentsField).toBeInTheDocument();
+      expect(commentsField).toHaveValue("delicious");
+
+      expect(submitButton).toHaveTextContent("Update");
+
+      fireEvent.change(itemField, {
+        target: { value: 22 },
+      });
+      fireEvent.change(reviewerField, {
+        target: { value: "phtcon@ucsb.edu" },
+      });
+      fireEvent.change(starsField, {
+        target: { value: 2 },
+      });
+      fireEvent.change(dateField, {
+        target: { value: "2022-03-15T16:02" },
+      });
+      fireEvent.change(commentsField, {
+        target: { value: "middling" },
+      });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "Menu Item Review Updated - id: 17 itemId: 22",
+      );
+
+      expect(mockNavigate).toBeCalledWith({ to: "/menuitemreview" });
+
+      expect(axiosMock.history.put.length).toBe(1); // times called
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          itemId: "22",
+          reviewerEmail: "phtcon@ucsb.edu",
+          stars: "2",
+          dateReviewed: "2022-03-15T16:02",
+          comments: "middling",
+        }),
+      ); // posted object
+    });
+
+    test("Changes when you click Update", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <MenuItemReviewEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("MenuItemReviewForm-id");
+
+      const idField = screen.getByTestId("MenuItemReviewForm-id");
+      const itemField = screen.getByTestId("MenuItemReviewForm-itemId");
+      const reviewerField = screen.getByTestId(
+        "MenuItemReviewForm-reviewerEmail",
+      );
+      const starsField = screen.getByTestId("MenuItemReviewForm-stars");
+      const dateField = screen.getByTestId("MenuItemReviewForm-dateReviewed");
+      const commentsField = screen.getByTestId("MenuItemReviewForm-comments");
+      const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
+
+      expect(idField).toBeInTheDocument();
+      expect(idField).toHaveValue("17");
+      expect(itemField).toBeInTheDocument();
+      expect(itemField).toHaveValue(21);
+      expect(reviewerField).toBeInTheDocument();
+      expect(reviewerField).toHaveValue("dqiao@ucsb.edu");
+      expect(starsField).toBeInTheDocument();
+      expect(starsField).toHaveValue(5);
+      expect(dateField).toBeInTheDocument();
+      expect(dateField).toHaveValue("2022-03-14T15:00");
+      expect(commentsField).toBeInTheDocument();
+      expect(commentsField).toHaveValue("delicious");
+
+      expect(submitButton).toHaveTextContent("Update");
+
+      fireEvent.change(itemField, {
+        target: { value: 22 },
+      });
+      fireEvent.change(reviewerField, {
+        target: { value: "phtcon@ucsb.edu" },
+      });
+      fireEvent.change(starsField, {
+        target: { value: 2 },
+      });
+      fireEvent.change(dateField, {
+        target: { value: "2022-03-15T16:02:20.200" },
+      });
+      fireEvent.change(commentsField, {
+        target: { value: "middling" },
+      });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "Menu Item Review Updated - id: 17 itemId: 22",
+      );
+      expect(mockNavigate).toBeCalledWith({ to: "/menuitemreview" });
+    });
   });
 });


### PR DESCRIPTION
Closes #42 

Storybook:

Steps: 
1. go to https://team02-st4lemon-dev.dokku-13.cs.ucsb.edu/ and login
2. go to MenuItemReview, you should see an index page:
![edit1](https://github.com/user-attachments/assets/8d0987b2-ace5-4b7c-a124-2bbae22ce784)

3. click edit for one of the reviews, this should take you to an edit page:
![edit2](https://github.com/user-attachments/assets/5f52b46b-3376-44b3-990c-5d9ad36bf192)

4. check for error messages-invalid inputs, empty inputs:
![edit3](https://github.com/user-attachments/assets/8ca2f69a-7498-4678-902b-9db428cd422c)

5. put in valid inputs, see that errors go away: 
![edit4](https://github.com/user-attachments/assets/2164d0cc-9b64-4084-a14e-abe336794819)

6. hit submit, edits should show up on index page 
![edit5](https://github.com/user-attachments/assets/02c8a6fc-d8b4-4294-ba31-a68c90f46453)
